### PR TITLE
Issue/7 optimize release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,22 +108,19 @@ jobs:
         VERSION=${GITHUB_REF#refs/tags/}
         
         # Update chart name to be more descriptive
-        sed -i "s/name: helm/name: mcp-operator/" helm/Chart.yaml
+        sed -i "s/name: helm/name: helm-mcp-operator/" helm/Chart.yaml
         sed -i "s/description: A Helm chart for Kubernetes/description: A Helm chart for MCP Operator/" helm/Chart.yaml
-        
+
         # Package Helm chart locally with descriptive name
         helm package helm --destination ./dist
-        
-        # Rename the package to be more descriptive
-        mv dist/mcp-operator-${VERSION#v}.tgz dist/helm-mcp-operator-${VERSION#v}.tgz
-        
+
         # Verify package was created
         if [ ! -f "dist/helm-mcp-operator-${VERSION#v}.tgz" ]; then
           echo "Error: Helm package not found"
           ls -la dist/
           exit 1
         fi
-        
+
         # Push Helm chart to ghcr.io as OCI artifact with helm prefix
         helm push dist/helm-mcp-operator-${VERSION#v}.tgz oci://${{ env.REGISTRY }}/v2dy/mcp-operator
         


### PR DESCRIPTION
## Description
Optimizes release workflow to reduce Docker build time from ~45 minutes to ~6-7 minutes.

## Changes
- Single Docker build with multiple tags (version + latest)
- Added build cache optimization  
- Fixed naming conflict between Docker image and Helm chart
- Updated image name from `kmcp` to `mcp-operator`

## Testing
- Tested with v0.1.2-test tag
- Build time reduced from 45+ minutes to ~6-7 minutes

Closes #7